### PR TITLE
Fix pathing issue + Allure diff screenshot fix + fix warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,21 +37,21 @@ class ResembleHelper extends Helper {
    * @returns {Promise<resolve | reject>}
    */
   async _compareImages(image, diffImage, options) {
-    const image1 = this.baseFolder + image;
-    const image2 = this.screenshotFolder + image;
+    const baseImage = this.baseFolder + image;
+    const actualImage = this.screenshotFolder + image;
 
     // check whether the base and the screenshot images are present.
-    fs.access(image1, fs.constants.F_OK | fs.constants.W_OK, (err) => {
+    fs.access(baseImage, fs.constants.F_OK | fs.constants.W_OK, (err) => {
       if (err) {
         throw new Error(
-          `${image1} ${err.code === 'ENOENT' ? 'base image does not exist' : 'is read-only'}`);
+          `${baseImage} ${err.code === 'ENOENT' ? 'base image does not exist' : 'is read-only'}`);
       }
     });
 
-    fs.access(image2, fs.constants.F_OK | fs.constants.W_OK, (err) => {
+    fs.access(actualImage, fs.constants.F_OK | fs.constants.W_OK, (err) => {
       if (err) {
         throw new Error(
-          `${image2} ${err.code === 'ENOENT' ? 'screenshot image does not exist' : 'is read-only'}`);
+          `${actualImage} ${err.code === 'ENOENT' ? 'screenshot image does not exist' : 'is read-only'}`);
       }
     });
 
@@ -65,14 +65,14 @@ class ResembleHelper extends Helper {
       this.debug("Tolerance Level Provided " + options.tolerance);
       const tolerance = options.tolerance;
 
-      resemble.compare(image1, image2, options, (err, data) => {
+      resemble.compare(baseImage, actualImage, options, (err, data) => {
         if (err) {
           reject(err);
         } else {
           if (!data.isSameDimensions) {
-            let dimensions1 = sizeOf(image1);
-            let dimensions2 = sizeOf(image2);
-            reject(new Error("The image1 is of " + dimensions1.height + " X " + dimensions1.width + " and image2 is of " + dimensions2.height + " X " + dimensions2.width + ". Please use images of same dimensions so as to avoid any unexpected results."));
+            let dimensions1 = sizeOf(baseImage);
+            let dimensions2 = sizeOf(actualImage);
+            reject(new Error("The base image is of " + dimensions1.height + " X " + dimensions1.width + " and actual image is of " + dimensions2.height + " X " + dimensions2.width + ". Please use images of same dimensions so as to avoid any unexpected results."));
           }
           resolve(data);
           if (data.misMatchPercentage >= tolerance) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class ResembleHelper extends Helper {
 
   resolvePath(folderPath) {
     if (!path.isAbsolute(folderPath)) {
-      return path.resolve(global.codecept_dir, folderPath) + "/"; // custom helper
+      return path.resolve(global.codecept_dir, folderPath) + "/";
     }
     return folderPath;
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "aws-sdk": "^2.476.0",
     "image-size": "^0.7.4"
   },
+  "devDependencies": {
+    "allure-commandline": "^2.13.0",
+    "codeceptjs": "^2.3.5"
+  },
   "keywords": [
     "codeceptJS",
     "codeceptjs",


### PR DESCRIPTION
Fixed pathing issue where when codecept is started from directory other than test root, baseFolder would not be found
Replace fs.writeFile with fs.writeFileSync to ensure the diff image is written before attached to allure.
Fix JSDoc warnings
Fix "err" scoping warning
Change undefined checks to check if element is either null or undefined
Remove unused parameter
Add check to ensure size is populated
fix overcomplicated ternary statement